### PR TITLE
ページ遷移の挙動がおかしかったので修正

### DIFF
--- a/src/app/components/HeaderSection.tsx
+++ b/src/app/components/HeaderSection.tsx
@@ -268,19 +268,19 @@ export default function HeaderSection() {
         </Link>
         <div className={navWrapperStyle}>
           <nav className={navStyle}>
-            <Link href="#service" className={navLinkStyle}>
+            <Link href="/#service" className={navLinkStyle}>
               サービス
             </Link>
-            <Link href="#member" className={navLinkStyle}>
+            <Link href="/#member" className={navLinkStyle}>
               メンバー紹介
             </Link>
-            <Link href="#news" className={navLinkStyle}>
+            <Link href="/#news" className={navLinkStyle}>
               ニュース
             </Link>
-            <Link href="#recruit" className={navLinkStyle}>
+            <Link href="/#recruit" className={navLinkStyle}>
               採用情報
             </Link>
-            <Link href="#company" className={navLinkStyle}>
+            <Link href="/#company" className={navLinkStyle}>
               会社概要
             </Link>
           </nav>
@@ -329,42 +329,42 @@ export default function HeaderSection() {
           className={closeButtonStyle}
         />
         <Link
-          href="#service"
+          href="/#service"
           onClick={closeMenu}
           style={{ margin: '24px 0 0 0', fontSize: '18px', color: '#444', textDecoration: 'none' }}
         >
           サービス
         </Link>
         <Link
-          href="#member"
+          href="/#member"
           onClick={closeMenu}
           style={{ margin: '24px 0 0 0', fontSize: '18px', color: '#444', textDecoration: 'none' }}
         >
           メンバー紹介
         </Link>
         <Link
-          href="#news"
+          href="/#news"
           onClick={closeMenu}
           style={{ margin: '24px 0 0 0', fontSize: '18px', color: '#444', textDecoration: 'none' }}
         >
           ニュース
         </Link>
         <Link
-          href="#recruit"
+          href="/#recruit"
           onClick={closeMenu}
           style={{ margin: '24px 0 0 0', fontSize: '18px', color: '#444', textDecoration: 'none' }}
         >
           採用情報
         </Link>
         <Link
-          href="#company"
+          href="/#company"
           onClick={closeMenu}
           style={{ margin: '24px 0 0 0', fontSize: '18px', color: '#444', textDecoration: 'none' }}
         >
           会社概要
         </Link>
         <Link
-          href="#gallery"
+          href="/#gallery"
           onClick={closeMenu}
           style={{ margin: '24px 0 0 0', fontSize: '18px', color: '#444', textDecoration: 'none' }}
         >

--- a/src/app/components/top/Hero/SplashWrapper.tsx
+++ b/src/app/components/top/Hero/SplashWrapper.tsx
@@ -11,6 +11,17 @@ export default function SplashWrapper({ children }: SplashWrapperProps) {
   const [showSplash, setShowSplash] = useState(true);
   const [splashCompleted, setSplashCompleted] = useState(false);
 
+  // 初回マウント時にアニメーションをスキップするかどうかを判定
+  useEffect(() => {
+    const hasSeenSplash = sessionStorage.getItem('hasSeenSplash');
+    const hasAnchorHash = window.location.hash && window.location.hash.length > 1;
+
+    if (hasSeenSplash || hasAnchorHash) {
+      setShowSplash(false);
+      setSplashCompleted(true);
+    }
+  }, []);
+
   // フェイルセーフ: 10秒で強制的にスプラッシュを閉じる
   useEffect(() => {
     if (!showSplash) return;
@@ -22,6 +33,8 @@ export default function SplashWrapper({ children }: SplashWrapperProps) {
   const handleSplashFinish = () => {
     setShowSplash(false);
     setSplashCompleted(true);
+    // アニメーションを見たことをセッションに記録する（アニメーションは初回のみトリガーさせるようにする）
+    sessionStorage.setItem('hasSeenSplash', 'true');
   };
 
   return (


### PR DESCRIPTION
### やったこと
- 問い合わせページから、ヘッダーの項目を選択する形でのページ遷移がうまくいってなかったので修正しました。

### 留意点
- 異なるページ間の移動でスプラッシュスクリーンが必ず発動しちゃっていたので、初回アクセス以外は同一セッション内においてスプラッシュスクリーンをトリガさせないようにしました。